### PR TITLE
Update tree project group to check if has child

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "wconsole-server",
+  "name": "spaceone-console-api",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/controllers/identity/project/tree-project.js
+++ b/src/controllers/identity/project/tree-project.js
@@ -17,17 +17,31 @@ const getProjectGroups = async (client, params) => {
         reqParams.parent_project_group_id = params.item_id;
     }
 
-    let response = await client.ProjectGroup.list(reqParams);
-    let items = [];
-    response.results.forEach((itemInfo) => {
+    let {results} = await client.ProjectGroup.list(reqParams);
+
+    reqParams.query.filter = [];
+
+    // eslint-disable-next-line no-undef
+    const items = await Promise.all(results.map((itemInfo) => {
+        const newParams = {
+            ...reqParams,
+            parent_project_group_id: itemInfo.project_group_id
+        };
+
         let item = {
             id: itemInfo.project_group_id,
             name: itemInfo.name,
             has_child: true,
             item_type: 'PROJECT_GROUP'
         };
-        items.push(item);
-    });
+
+        // eslint-disable-next-line no-undef
+        return new Promise((resolve) => {
+            client.ProjectGroup.list(newParams).then(({total_count}) => {
+                item.has_child = !!total_count;
+            }).finally(() => resolve(item));
+        });
+    }));
 
     return items;
 };

--- a/src/controllers/identity/project/tree-project.js
+++ b/src/controllers/identity/project/tree-project.js
@@ -20,6 +20,7 @@ const getProjectGroups = async (client, params) => {
     let {results} = await client.ProjectGroup.list(reqParams);
 
     reqParams.query.filter = [];
+    reqParams.query.count_only = true;
 
     // eslint-disable-next-line no-undef
     const items = await Promise.all(results.map((itemInfo) => {

--- a/src/controllers/identity/project/tree-project.js
+++ b/src/controllers/identity/project/tree-project.js
@@ -19,13 +19,12 @@ const getProjectGroups = async (client, params) => {
 
     let {results} = await client.ProjectGroup.list(reqParams);
 
-    reqParams.query.filter = [];
-    reqParams.query.count_only = true;
+    const childCheckQuery = { count_only: true };
 
     // eslint-disable-next-line no-undef
     const items = await Promise.all(results.map((itemInfo) => {
         const newParams = {
-            ...reqParams,
+            query: childCheckQuery,
             parent_project_group_id: itemInfo.project_group_id
         };
 


### PR DESCRIPTION
has_child 체크를 클라이언트에서 하는 것보다 node 에서 하는 것이 좋을 것 같아 추가하였습니다.
추후에 has_child 체크를 할지 여부를 params에 추가하는게 좋을 것 같습니다.