### PR TITLE
Add a getSpotGroupServers API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ node_modules/
 # Transpiled code
 dist
 
-
-
-
 # Dev tools
 .DS_Store
 .vscode

--- a/src/controllers/spot-automation/spot-group/index.ts
+++ b/src/controllers/spot-automation/spot-group/index.ts
@@ -110,16 +110,19 @@ const getSpotGroupServers = async (params) => {
                     o: 'in'
                 }
             ],
-            only: ['server_id']
+            only: ['server_id', 'name']
         }
     };
     const serversInfo = await listServers(requestParams);
-    const serverIds = serversInfo.results.map((serverInfo) => {
-        return serverInfo.server_id;
+    const results = serversInfo.results.map((serverInfo) => {
+        return {
+            server_id: serverInfo.server_id,
+            name: serverInfo.name
+        };
     });
 
     return {
-        'results': serverIds
+        'results': results
     };
 };
 

--- a/src/controllers/spot-automation/spot-group/index.ts
+++ b/src/controllers/spot-automation/spot-group/index.ts
@@ -100,26 +100,31 @@ const getSpotGroupResource = async (params) => {
 
 const getSpotGroupServers = async (params) => {
     const resourceInfo = await getSpotGroupResource(params);
-    const instanceIds = getValueByPath(resourceInfo, 'data.instances.instance_id');
-    const requestParams = {
-        query: {
-            filter: [
-                {
-                    k: 'reference.resource_id',
-                    v: instanceIds,
-                    o: 'in'
-                }
-            ],
-            only: ['server_id', 'name']
-        }
-    };
-    const serversInfo = await listServers(requestParams);
-    const results = serversInfo.results.map((serverInfo) => {
-        return {
-            server_id: serverInfo.server_id,
-            name: serverInfo.name
+    const resourceType = `${resourceInfo['provider']}.${resourceInfo['cloud_service_group']}.${resourceInfo['cloud_service_type']}`;
+    let results = [];
+
+    if (resourceType === 'aws.EC2.AutoScalingGroup') {
+        const instanceIds = getValueByPath(resourceInfo, 'data.instances.instance_id');
+        const requestParams = {
+            query: {
+                filter: [
+                    {
+                        k: 'reference.resource_id',
+                        v: instanceIds,
+                        o: 'in'
+                    }
+                ],
+                only: ['server_id', 'name']
+            }
         };
-    });
+        const serversInfo = await listServers(requestParams);
+        results = serversInfo.results.map((serverInfo) => {
+            return {
+                server_id: serverInfo.server_id,
+                name: serverInfo.name
+            };
+        });
+    }
 
     return {
         'results': results

--- a/src/routes/spot-automation/spot-group.ts
+++ b/src/routes/spot-automation/spot-group.ts
@@ -13,7 +13,8 @@ const controllers = [
     { url: '/interrupt', func: spotGroup.interruptSpotGroups },
     { url: '/stat', func: spotGroup.statSpotGroups },
     { url: '/get-candidates', func: spotGroup.getCandidates },
-    { url: '/get-supported-resource-types', func: spotGroup.getSupportedResourceTypes }
+    { url: '/get-supported-resource-types', func: spotGroup.getSupportedResourceTypes },
+    { url: '/get-spot-group-servers', func: spotGroup.getSpotGroupServers }
 ];
 
 controllers.forEach((config) => {


### PR DESCRIPTION
### 작업 개요
spot_group_id로 연결된 server_id 목록을 추출하는 API 개발

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
spot_group에 연결된 resource_id로 서버 또는 클라우드 서비스 정보 추출 후 그 안에 있는 Instance 정보를 바탕으로 server_id를 가져오도록 개발

### 생각해볼 문제
아직 AutoScalingGroup 외 다른 리소스 타입은 처리하지 않았으며, 다른 타입이 생길 경우 추가 구현 필요
