### PR TITLE
Add get cloud service type of spot group API

### DIFF
--- a/src/controllers/spot-automation/spot-group/config.ts
+++ b/src/controllers/spot-automation/spot-group/config.ts
@@ -10,3 +10,16 @@ export const SUPPORTED_RESOURCE_TYPES = {
         icon: 'https://spaceone-custom-assets.s3.ap-northeast-2.amazonaws.com/console-assets/icons/cloud-services/aws/Amazon-Elastic-Kubernetes-Service.svg'
     }
 };
+
+export const SERVICE_TYPE = {
+    'AutoScalingGroup': {
+        'name': '[AWS] Auto Scaling Group',
+        'recommended_title': 'Auto Scaling Group',
+        provider: 'AWS'
+    },
+    'Cluster': {
+        'name': '[AWS] EKS Node Group',
+        'recommended_title': 'EKS Node Group',
+        provider: 'AWS'
+    }
+};

--- a/src/controllers/spot-automation/spot-group/index.ts
+++ b/src/controllers/spot-automation/spot-group/index.ts
@@ -2,7 +2,7 @@ import grpcClient from '@lib/grpc-client';
 import { getValueByPath } from '@lib/utils';
 import { getServer, listServers } from '@controllers/inventory/server';
 import { getCloudService } from '@controllers/inventory/cloud-service';
-import { SUPPORTED_RESOURCE_TYPES } from './config';
+import {SERVICE_TYPE, SUPPORTED_RESOURCE_TYPES} from './config';
 
 
 const createSpotGroup = async (params) => {
@@ -66,6 +66,14 @@ const getSupportedResourceTypes = () => {
     return SUPPORTED_RESOURCE_TYPES;
 };
 
+const getCloudServiceType = async (spotGroupId) => {
+    const spotAutomationV1 = await grpcClient.get('spot_automation', 'v1');
+    const response = await spotAutomationV1.SpotGroup.get(spotGroupId);
+    if (response.cloud_service_type) {
+        return SERVICE_TYPE[response.cloud_service_type];
+    } else return {};
+};
+
 
 export {
     createSpotGroup,
@@ -76,5 +84,6 @@ export {
     interruptSpotGroups,
     statSpotGroups,
     getCandidates,
-    getSupportedResourceTypes
+    getSupportedResourceTypes,
+    getCloudServiceType,
 };

--- a/src/routes/spot-automation/spot-group.ts
+++ b/src/routes/spot-automation/spot-group.ts
@@ -19,7 +19,8 @@ const controllers = [
     { url: '/get-supported-resource-types', func: spotGroup.getSupportedResourceTypes },
     { url: '/get-spot-group-servers', func: getSpotGroupServers },
     { url: '/get-spot-group-instance-count', func: getSpotGroupInstanceCount },
-    { url: '/member/list', func: listSpotGroupMembers}
+    { url: '/member/list', func: listSpotGroupMembers},
+    { url: '/get-cloud-service-type', func: spotGroup.getCloudServiceType },
 ];
 
 controllers.forEach((config) => {


### PR DESCRIPTION
### 작업 개요
Spot Group의 service type을 가져오는 API

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
<img width="114" alt="스크린샷 2021-04-01 오후 9 35 19" src="https://user-images.githubusercontent.com/35549653/113294600-28f93280-9332-11eb-9624-7c6f08706e7d.png">
카드 UI에서 위 부분에 해당하는 데이터가 현재 'AutoScalingGroup' 등으로 오고 있어, 콘솔에서 편리하게 표기하고자 API를 작성함

