### PR TITLE
Add get-spot-group-by-project API and Bugfix

### DIFF
--- a/src/controllers/spot-automation/spot-group/get-spot-group-by-project.ts
+++ b/src/controllers/spot-automation/spot-group/get-spot-group-by-project.ts
@@ -1,0 +1,68 @@
+//@ts-nocheck
+import { statSpotGroups } from '@controllers/spot-automation/spot-group';
+
+const getDefaultQuery = () => {
+    return {
+        query: {
+            aggregate: [
+                {
+                    group: {
+                        keys: [
+                            {
+                                key: 'project_id',
+                                name: 'project_id'
+                            }
+                        ],
+                        fields: [
+                            {
+                                name: 'spot_group_count',
+                                key: 'spot_group_id',
+                                operator: 'count'
+                            }
+                        ]
+                    }
+                }
+            ],
+            filter: []
+        }
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.projects) {
+        throw new Error('Required Parameter. (key = projects)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    requestParams['query']['filter'].push({
+        k: 'project_id',
+        v: params.projects,
+        o: 'in'
+    });
+
+    return requestParams;
+};
+
+const makeResponse = (results, projects) => {
+    const projectResults = {};
+    projects.forEach((projectId) => {
+        projectResults[projectId] = 0;
+    });
+
+    results.forEach((item) => {
+        projectResults[item.project_id] = item.spot_group_count;
+    });
+
+    return {
+        projects: projectResults
+    };
+};
+
+const getSpotGroupByProject = async (params) => {
+    const requestParams = makeRequest(params);
+    const response = await statSpotGroups(requestParams);
+    return makeResponse(response.results, params.projects);
+};
+
+export default getSpotGroupByProject;

--- a/src/controllers/spot-automation/spot-group/get-spot-group-instance-cpu.ts
+++ b/src/controllers/spot-automation/spot-group/get-spot-group-instance-cpu.ts
@@ -37,7 +37,7 @@ const makeResponse = async (spotGroupServers) => {
 
         const response = await statServers(requestParams);
         spotGroupsCPUUtilization[spotGroupId] = {
-            cpu_utilization: (response.results.length > 0)?response.results[0].cpu_utilization: 0
+            cpu_utilization: (response.results.length > 0)?response.results[0].cpu_utilization || 0: 0
         };
     });
 

--- a/src/routes/spot-automation/spot-group.ts
+++ b/src/routes/spot-automation/spot-group.ts
@@ -18,6 +18,7 @@ import getSpotGroupCloudServiceType from '@controllers/spot-automation/spot-grou
 import getSpotGroupInterrupt from '@controllers/spot-automation/spot-group/get-spot-group-interrupt';
 import getSpotGroupInterruptHistory from '@controllers/spot-automation/spot-group/get-spot-group-interrupt-history';
 import getSpotGroupInterruptSummary from '@controllers/spot-automation/spot-group/get-spot-group-interrupt-summary';
+import getSpotGroupByProject from '@controllers/spot-automation/spot-group/get-spot-group-by-project';
 
 const router = express.Router();
 
@@ -47,7 +48,8 @@ const controllers = [
     { url: '/get-spot-group-cloud-service-type', func: getSpotGroupCloudServiceType },
     { url: '/get-spot-group-interrupt', func: getSpotGroupInterrupt },
     { url: '/get-spot-group-interrupt-history', func: getSpotGroupInterruptHistory },
-    { url: '/get-spot-group-interrupt-summary', func: getSpotGroupInterruptSummary }
+    { url: '/get-spot-group-interrupt-summary', func: getSpotGroupInterruptSummary },
+    { url: '/get-spot-group-by-project', func: getSpotGroupByProject }
 ];
 
 controllers.forEach((config) => {


### PR DESCRIPTION
### 작업 개요
프로젝트 별 Spot Group 개수를 가져오는 API 추가 개발
Spot Group 내 인스턴스 평균 CPU 조회 시 null을 리턴하는 버그 수정

### 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
