### PR TITLE
Add requestBodySize option

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -13,6 +13,7 @@
     "enabled": true,
     "ttl": 300
   },
+  "requestBodySize": "10mb",
   "endpoints": {
     "identity": {
       "v1": "identity:50051"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cookieParser from 'cookie-parser';
+import config from 'config';
 import cors from 'cors';
 import expressHealthCheck from 'express-healthcheck';
 import httpContext from 'express-http-context';
@@ -12,8 +13,8 @@ import indexRouter from 'routes';
 const app = express();
 
 app.use(cors(corsOptions));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: config.get('requestBodySize') || '10mb' }));
+app.use(express.urlencoded({ limit: config.get('requestBodySize') || '10mb', extended: false }));
 app.use(cookieParser());
 
 app.use(httpContext.middleware);


### PR DESCRIPTION
Signed-off-by: Jongmin Kim <whdalsrnt@megazone.com>

### 작업 개요
Cloud Service의 Excel Export 시 Request body size가 100kb가 넘어가는 문제로 "PayloadTooLargeError: request entity too large." 에러 발생
`requestBodysize` 옵션을 추가하여 해결함

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경


