### PR TITLE
feat: add monitoring dashboard apis

### DIFF
--- a/src/controllers/monitoring/dashboard/alert-by-project.ts
+++ b/src/controllers/monitoring/dashboard/alert-by-project.ts
@@ -1,0 +1,109 @@
+import grpcClient from '@lib/grpc-client';
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.Alert',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'alert_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': [
+                                    'TRIGGERED',
+                                    'ACKNOWLEDGED'
+                                ],
+                                'operator': 'in'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.MaintenanceWindow',
+                    'keys': [
+                        'project_id'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'unwind': {
+                                    'path': 'projects'
+                                }
+                            },
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'projects',
+                                            'name': 'project_id'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'maintenance_window_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': 'OPEN',
+                                'operator': 'eq'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'fill_na': {
+                    'data': {
+                        'alert_count': 0,
+                        'maintenance_window_count': 0
+                    }
+                }
+            },
+            {
+                'sort': {
+                    'key': 'alert_count',
+                    'desc': true
+                }
+            }
+        ],
+        'page': {
+            'limit': 5
+        }
+    };
+};
+
+const alertByProject = async () => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = getDefaultQuery();
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default alertByProject;
+

--- a/src/controllers/monitoring/dashboard/alert-count-by-state.ts
+++ b/src/controllers/monitoring/dashboard/alert-count-by-state.ts
@@ -1,4 +1,4 @@
-import {statAlerts} from '@controllers/monitoring/alert';
+import { statAlerts } from '@controllers/monitoring/alert';
 
 const getDefaultQuery = () => {
     return {
@@ -14,7 +14,6 @@ const getDefaultQuery = () => {
                         ],
                         fields: [
                             {
-                                key: 'alert_id',
                                 name: 'total',
                                 operator: 'count'
                             }
@@ -22,7 +21,13 @@ const getDefaultQuery = () => {
                     }
                 }
             ],
-            filter: [] as any
+            filter: [
+                {
+                    key: 'state',
+                    value: 'ERROR',
+                    operator: 'not'
+                }
+            ] as any
         }
     };
 };
@@ -52,10 +57,10 @@ const makeResponse = async (params) => {
     return await statAlerts(params);
 };
 
-const alertStateCount = async (params) => {
+const alertCountByState = async (params) => {
     const requestParams = makeRequest(params);
     return makeResponse(requestParams);
 };
 
-export default alertStateCount;
+export default alertCountByState;
 

--- a/src/controllers/monitoring/dashboard/alert-history-summary.ts
+++ b/src/controllers/monitoring/dashboard/alert-history-summary.ts
@@ -1,0 +1,128 @@
+import grpcClient from '@lib/grpc-client';
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.Alert',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'total_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [] as any
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.Alert',
+                    'keys': [
+                        'date'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'resolved_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': 'RESOLVED',
+                                'operator': 'eq'
+                            }
+                        ] as any
+                    }
+                }
+            },
+            {
+                'fill_na': {
+                    'data': {
+                        'total_count': 0,
+                        'resolved_count': 0
+                    }
+                }
+            }
+        ]
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.start) {
+        throw new Error('Required Parameter. (key = start)');
+    }
+
+    if (!params.end) {
+        throw new Error('Required Parameter. (key = end)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    // @ts-ignore
+    requestParams['aggregate'][0]['query']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.start,
+        'o': 'datetime_gte'
+    });
+    // @ts-ignore
+    requestParams['aggregate'][0]['query']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.end,
+        'o': 'datetime_lt'
+    });
+
+    // @ts-ignore
+    requestParams['aggregate'][1]['join']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.start,
+        'o': 'datetime_gte'
+    });
+    // @ts-ignore
+    requestParams['aggregate'][1]['join']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.end,
+        'o': 'datetime_lt'
+    });
+
+    return requestParams;
+};
+
+const alertHistorySummary = async (params) => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = makeRequest(params);
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default alertHistorySummary;
+

--- a/src/controllers/monitoring/dashboard/current-project-status.ts
+++ b/src/controllers/monitoring/dashboard/current-project-status.ts
@@ -1,0 +1,115 @@
+import grpcClient from '@lib/grpc-client';
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.ProjectAlertConfig',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.Alert',
+                    'keys': [
+                        'project_id'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': [
+                                    'TRIGGERED',
+                                    'ACKNOWLEDGED'
+                                ],
+                                'operator': 'in'
+                            }
+                        ]
+                    },
+                    'extend_data': {
+                        'is_issued': true
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.MaintenanceWindow',
+                    'keys': [
+                        'project_id'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'unwind': {
+                                    'path': 'projects'
+                                }
+                            },
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'projects',
+                                            'name': 'project_id'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': 'OPEN',
+                                'operator': 'eq'
+                            }
+                        ]
+                    },
+                    'extend_data': {
+                        'is_maintenance_window': 'true'
+                    }
+                }
+            },
+            {
+                'fill_na': {
+                    'data': {
+                        'is_issued': false
+                    }
+                }
+            },
+        ]
+    };
+};
+
+const currentProjectStatus = async () => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = getDefaultQuery();
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default currentProjectStatus;
+

--- a/src/controllers/monitoring/dashboard/daily-alert-history.ts
+++ b/src/controllers/monitoring/dashboard/daily-alert-history.ts
@@ -1,0 +1,164 @@
+import grpcClient from '@lib/grpc-client';
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.Alert',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m-%d'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'total_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                'sort': {
+                                    'key': 'date'
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'k': 'created_at',
+                                'v': '2021-06-01T00:00:00Z',
+                                'o': 'datetime_gte'
+                            },
+                            {
+                                'k': 'created_at',
+                                'v': '2021-07-01T00:00:00Z',
+                                'o': 'datetime_lt'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.Alert',
+                    'keys': [
+                        'date'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m-%d'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'resolved_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                'sort': {
+                                    'key': 'date'
+                                }
+                            }
+                        ],
+                        'filter': [
+                            {
+                                'key': 'state',
+                                'value': 'RESOLVED',
+                                'operator': 'eq'
+                            },
+                            {
+                                'k': 'created_at',
+                                'v': '2021-06-01T00:00:00Z',
+                                'o': 'datetime_gte'
+                            },
+                            {
+                                'k': 'created_at',
+                                'v': '2021-07-01T00:00:00Z',
+                                'o': 'datetime_lt'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'fill_na': {
+                    'data': {
+                        'total_count': 0,
+                        'resolved_count': 0
+                    }
+                }
+            },
+            {
+                'formula': {
+                    'eval': 'open_count = total_count - resolved_count'
+                }
+            }
+        ]
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.start) {
+        throw new Error('Required Parameter. (key = start)');
+    }
+
+    if (!params.end) {
+        throw new Error('Required Parameter. (key = end)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    // @ts-ignore
+    requestParams['aggregate'][0]['query']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.start,
+        'o': 'datetime_gte'
+    });
+    // @ts-ignore
+    requestParams['aggregate'][0]['query']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.end,
+        'o': 'datetime_lt'
+    });
+
+    // @ts-ignore
+    requestParams['aggregate'][1]['join']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.start,
+        'o': 'datetime_gte'
+    });
+    // @ts-ignore
+    requestParams['aggregate'][1]['join']['query']['filter'].push({
+        'k': 'created_at',
+        'v': params.end,
+        'o': 'datetime_lt'
+    });
+
+    return requestParams;
+};
+
+const dailyAlertHistory = async (params) => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = makeRequest(params);
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default dailyAlertHistory;
+

--- a/src/controllers/monitoring/dashboard/top5-project-activity-alert-details.ts
+++ b/src/controllers/monitoring/dashboard/top5-project-activity-alert-details.ts
@@ -1,0 +1,109 @@
+import grpcClient from '@lib/grpc-client';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.Alert',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'urgency',
+                                            'name': 'urgency'
+                                        },
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m-%d'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'has_alert',
+                                            'key': 'urgency',
+                                            'operator': 'size'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [] as any
+                    }
+                }
+            },
+            {
+                'sort': {
+                    'key': 'date'
+                }
+            }
+        ]
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.project_id) {
+        throw new Error('Required Parameter. (key = project_id)');
+    }
+
+    if (!params.period) {
+        throw new Error('Required Parameter. (key = period)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    // @ts-ignore
+    requestParams.aggregate[0].query.query.filter.push({
+        k: 'project_id',
+        v: params.project_id,
+        o: 'eq'
+    });
+
+    if (params.period.includes('d')) {
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d';
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            k: 'created_at',
+            v: `now/d-${params.period}`,
+            o: 'timediff_gte'
+        });
+    } else {
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d %H';
+
+        const now = dayjs.utc();
+        const hour = parseInt(params.period.match(/\d+/)[0]);
+
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            k: 'created_at',
+            v: now.subtract(hour, 'hours').toISOString(),
+            o: 'datetime_gte'
+        });
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            'k': 'created_at',
+            'v': now.toISOString(),
+            'o': 'datetime_lt'
+        });
+    }
+
+    return requestParams;
+};
+
+const top5ProjectActivityAlertDetails = async (params) => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = makeRequest(params);
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default top5ProjectActivityAlertDetails;
+

--- a/src/controllers/monitoring/dashboard/top5-project-activity-list.ts
+++ b/src/controllers/monitoring/dashboard/top5-project-activity-list.ts
@@ -1,0 +1,155 @@
+import grpcClient from '@lib/grpc-client';
+import dayjs from 'dayjs';
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.ProjectAlertConfig',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'join': {
+                    'resource_type': 'monitoring.Alert',
+                    'keys': [
+                        'project_id'
+                    ],
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        },
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m-%d %H'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'has_alert',
+                                            'key': 'project_id',
+                                            'operator': 'size'
+                                        },
+                                        {
+                                            'name': 'alert_count',
+                                            'operator': 'count'
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'project_id',
+                                            'name': 'project_id'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'score',
+                                            'key': 'has_alert',
+                                            'operator': 'sum'
+                                        },
+                                        {
+                                            'name': 'alert_count',
+                                            'key': 'alert_count',
+                                            'operator': 'sum'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [] as any
+                    }
+                }
+            },
+            {
+                'fill_na': {
+                    'data': {
+                        'alert_count': 0,
+                        'score': 0
+                    }
+                }
+            },
+            {
+                'sort': {
+                    'key': 'score',
+                    'desc': true
+                }
+            }
+        ],
+        'page': {
+            'limit': 5
+        }
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.period) {
+        throw new Error('Required Parameter. (key = period)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    if (params.period.includes('d')) {
+        // @ts-ignore
+        requestParams.aggregate[1].join.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d';
+        // @ts-ignore
+        requestParams.aggregate[1].join.query.filter.push({
+            k: 'created_at',
+            v: `now/d-${params.period}`,
+            o: 'timediff_gte'
+        });
+    } else {
+        // @ts-ignore
+        requestParams.aggregate[1].join.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d %H';
+
+        const now = dayjs.utc();
+        const hour = parseInt(params.period.match(/\d+/)[0]);
+
+        // @ts-ignore
+        requestParams.aggregate[1].join.query.filter.push({
+            k: 'created_at',
+            v: now.subtract(hour, 'hours').toISOString(),
+            o: 'datetime_gte'
+        });
+        // @ts-ignore
+        requestParams.aggregate[1].join.query.filter.push({
+            'k': 'created_at',
+            'v': now.toISOString(),
+            'o': 'datetime_lt'
+        });
+    }
+
+    return requestParams;
+};
+
+const top5ProjectActivityList = async (params) => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = makeRequest(params);
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default top5ProjectActivityList;
+

--- a/src/controllers/monitoring/dashboard/top5-project-activity-maintenance-details.ts
+++ b/src/controllers/monitoring/dashboard/top5-project-activity-maintenance-details.ts
@@ -1,0 +1,109 @@
+import grpcClient from '@lib/grpc-client';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+const getDefaultQuery = () => {
+    return {
+        'aggregate': [
+            {
+                'query': {
+                    'resource_type': 'monitoring.Alert',
+                    'query': {
+                        'aggregate': [
+                            {
+                                'group': {
+                                    'keys': [
+                                        {
+                                            'key': 'urgency',
+                                            'name': 'urgency'
+                                        },
+                                        {
+                                            'key': 'created_at',
+                                            'name': 'date',
+                                            'date_format': '%Y-%m-%d'
+                                        }
+                                    ],
+                                    'fields': [
+                                        {
+                                            'name': 'has_alert',
+                                            'key': 'urgency',
+                                            'operator': 'size'
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        'filter': [] as any
+                    }
+                }
+            },
+            {
+                'sort': {
+                    'key': 'date'
+                }
+            }
+        ]
+    };
+};
+
+const makeRequest = (params) => {
+    if (!params.project_id) {
+        throw new Error('Required Parameter. (key = project_id)');
+    }
+
+    if (!params.period) {
+        throw new Error('Required Parameter. (key = period)');
+    }
+
+    const requestParams = getDefaultQuery();
+
+    // @ts-ignore
+    requestParams.aggregate[0].query.query.filter.push({
+        k: 'project_id',
+        v: params.project_id,
+        o: 'eq'
+    });
+
+    if (params.period.includes('d')) {
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d';
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            k: 'created_at',
+            v: `now/d-${params.period}`,
+            o: 'timediff_gte'
+        });
+    } else {
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.aggregate[0].group.keys[1].date_format = '%Y-%m-%d %H';
+
+        const now = dayjs.utc();
+        const hour = parseInt(params.period.match(/\d+/)[0]);
+
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            k: 'created_at',
+            v: now.subtract(hour, 'hours').toISOString(),
+            o: 'datetime_gte'
+        });
+        // @ts-ignore
+        requestParams.aggregate[0].query.query.filter.push({
+            'k': 'created_at',
+            'v': now.toISOString(),
+            'o': 'datetime_lt'
+        });
+    }
+
+    return requestParams;
+};
+
+const top5ProjectActivityMaintenanceDetails = async (params) => {
+    const statistics = await grpcClient.get('statistics');
+    const requestParams = makeRequest(params);
+    return await statistics.Resource.stat(requestParams);
+};
+
+export default top5ProjectActivityMaintenanceDetails;
+

--- a/src/routes/monitoring/dashboard.ts
+++ b/src/routes/monitoring/dashboard.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import alertCountByState from '@controllers/monitoring/dashboard/alert-count-by-state';
+import alertHistorySummary from '@controllers/monitoring/dashboard/alert-history-summary';
+import dailyAlertHistory from '@controllers/monitoring/dashboard/daily-alert-history';
+import alertByProject from '@controllers/monitoring/dashboard/alert-by-project';
+import currentProjectStatus from '@controllers/monitoring/dashboard/current-project-status';
+import top5ProjectActivityList from '@controllers/monitoring/dashboard/top5-project-activity-list';
+import top5ProjectActivityAlertDetails from '@controllers/monitoring/dashboard/top5-project-activity-alert-details';
+
+const router = express.Router();
+
+const controllers = [
+    { url: '/alert-count-by-state', func: alertCountByState },
+    { url: '/alert-history-summary', func: alertHistorySummary },
+    { url: '/daily-alert-history', func: dailyAlertHistory },
+    { url: '/alert-by-project', func: alertByProject },
+    { url: '/current-project-status', func: currentProjectStatus },
+    { url: '/top5-project-activity-list', func: top5ProjectActivityList },
+    { url: '/top5-project-activity-alert-details', func: top5ProjectActivityAlertDetails }
+];
+
+controllers.forEach((config) => {
+    router.post(config.url, asyncHandler(async (req, res) => {
+        res.json(await config.func(req.body));
+    }));
+});
+
+export default router;

--- a/src/routes/monitoring/index.ts
+++ b/src/routes/monitoring/index.ts
@@ -10,6 +10,7 @@ import noteRouter from './note';
 import maintenanceWindowRouter from './maintenance-window';
 import eventRuleRouter from './event-rule';
 import eventRouter from './event';
+import dashboardRouter from './dashboard';
 
 const router = express.Router();
 
@@ -24,4 +25,5 @@ router.use('/note', noteRouter);
 router.use('/maintenance-window', maintenanceWindowRouter);
 router.use('/event-rule', eventRuleRouter);
 router.use('/event', eventRouter);
+router.use('/dashboard', dashboardRouter);
 export default router;

--- a/src/routes/statistics/topic.ts
+++ b/src/routes/statistics/topic.ts
@@ -25,7 +25,6 @@ import billingSummary from '@controllers/statistics/topic/billing-summary';
 import spotAutomationSavingCost from '@controllers/statistics/topic/spot-automation-saving-cost';
 import spotAutomationInstanceCount from '@controllers/statistics/topic/spot-automation-instance-count';
 import spotAutomationSpotGroupCount from '@controllers/statistics/topic/spot-automation-spot-group-count';
-import alertStateCount from '@controllers/statistics/topic/alert-state-count';
 
 const router = express.Router();
 
@@ -54,8 +53,7 @@ const controllers = [
     { url: '/billing-summary', func: billingSummary },
     { url: '/spot-automation-saving-cost', func: spotAutomationSavingCost },
     { url: '/spot-automation-instance-count', func: spotAutomationInstanceCount },
-    { url: '/spot-automation-spot-group-count', func: spotAutomationSpotGroupCount },
-    { url: '/alert-state-count', func: alertStateCount }
+    { url: '/spot-automation-spot-group-count', func: spotAutomationSpotGroupCount }
 ];
 
 controllers.forEach((config) => {


### PR DESCRIPTION
### 작업 개요
monitoring dashboard를 위한 api들 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 기존 statistics/topic 아래에 있던 alert-state-count.ts를 monitoring/dashboard 아래로 옮김 (alert-count-by-state.ts)
- monitoring 아래 dashboard 폴더를 만들어 그 아래 api들 추가
