### PR TITLE
fix: service account summary query

### DIFF
--- a/src/controllers/statistics/topic/service-account-summary.ts
+++ b/src/controllers/statistics/topic/service-account-summary.ts
@@ -31,7 +31,7 @@ const getDefaultQuery = () => {
                         'filter': [
                             {
                                 'k': 'provider',
-                                'v': ['aws', 'google_cloud', 'azure'],
+                                'v': ['aws', 'google_cloud', 'azure', 'oracle_cloud', 'alibaba_cloud', 'hyperbilling', 'spaceone'],
                                 'o': 'in'
                             }
                         ]


### PR DESCRIPTION
### 작업 개요
service account summary
### Jira
https://discuss.spaceone.org/t/spaceone-service-account/44/4
### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
위의 이슈를 확인했을 때, provider를 추가해도 project 대시보드 내의 service account summary에 나오지 않는 버그가 있습니다.
일단 첫번째 이유는 시간차 때문이고, (추가하고 조금 시간이 지나고 새로고침하니 나오더라구요) 
두 번째 이유는 프로바이더들이 추가되지않아서입니다. 
그래서 위와 같이 프로바이더를 추가합니다.
### 생각해볼 문제
이렇게 정적으로 넣지 않고, 프로바이더 목록을 가져와서 넣어주고싶습니다
